### PR TITLE
Conversation Short-cut

### DIFF
--- a/WhatsApp Shortcuts.user.js
+++ b/WhatsApp Shortcuts.user.js
@@ -15,6 +15,11 @@
     let currentReply = null;
 
     const WhatsApp = {
+        conversation : {
+            currentConversationIndex: 0,
+            totalConversationElements: 0,
+        },
+
         findParent: function(el, sel) {
             while ((el = el.parentElement) && !((el.matches || el.matchesSelector).call(el, sel)));
             return el;
@@ -53,8 +58,86 @@
             }
 
             return currentReply.nextSibling;
-        }
+        },
+
+        getConversation(){
+            return document.querySelectorAll('#pane-side .X7YrQ div._2UaNq');
+         }
     }
+
+    function addEventListenerToConversation(){
+        const conversationsElements = WhatsApp.getConversation();
+        WhatsApp.conversation.totalConversationElements= conversationsElements.length;
+
+        conversationsElements.forEach((conversationElement, index) => {
+            conversationElement.addEventListener('click',() => {
+                WhatsApp.conversation.currentConversationIndex = index;                    
+            });
+        });
+    }
+
+    function bindChangeOfConversation(){
+
+        const event = new MouseEvent('onMouseDown', {
+            'view': window,
+            'bubbles': true,
+            'cancelable': true
+        });
+
+        Mousetrap.bind(['down'], function() {
+        try{
+
+
+            const currentIndex = WhatsApp.conversation.currentConversationIndex;
+            const totalIndex = WhatsApp.conversation.totalConversationElements;
+
+            const nextIndex = (totalIndex + currentIndex - 1) %totalIndex;                
+
+            const nextElement = WhatsApp.getConversation()[nextIndex];
+            if(!nextElement) return;                
+
+            const reactHandlerKey=Object.keys(nextElement).filter(function(item){
+                return item.indexOf('__reactEventHandlers')>=0
+             });
+            const reactHandler=nextElement[reactHandlerKey[0]];
+             
+            reactHandler.onMouseDown(event);
+            WhatsApp.conversation.currentConversationIndex = nextIndex;
+
+            }
+        catch(err){
+            console.log(err);
+                
+            }
+        });
+
+        Mousetrap.bind(['up'], function() {
+            try{
+
+                const currentIndex = WhatsApp.conversation.currentConversationIndex;
+                const totalIndex = WhatsApp.conversation.totalConversationElements;
+
+                const nextIndex = (totalIndex + currentIndex + 1) %totalIndex;
+
+                const nextElement = WhatsApp.getConversation()[nextIndex];
+
+                if(!nextElement) return;                
+
+                const reactHandlerKey=Object.keys(nextElement).filter(function(item){
+                    return item.indexOf('__reactEventHandlers')>=0
+                 });
+                const reactHandler=nextElement[reactHandlerKey[0]];
+                 
+                reactHandler.onMouseDown(event);
+                WhatsApp.conversation.currentConversationIndex = nextIndex;
+
+            }
+            catch(err){
+                console.log(err);  
+            }
+        });
+    }
+
 
     function doubleClick(selector, _element = null) {
         const element = _element || document.querySelector(selector);
@@ -129,6 +212,9 @@
 
         bindSearch();
         bindChangeConversation();
+        addEventListenerToConversation();
+        bindChangeOfConversation();
+            
 
         document.addEventListener("keydown", function(e) {
             if (e.target.classList.contains("selectable-text")) {

--- a/WhatsApp Shortcuts.user.js
+++ b/WhatsApp Shortcuts.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         WhatsApp Shortcuts
 // @namespace    WA-Shortcuts
-// @version      0.1
+// @version      0.2
 // @description  Adding shortcuts to WhatsApp web application.
 // @author       lai32290
 // @match        https://web.whatsapp.com/

--- a/WhatsApp Shortcuts.user.js
+++ b/WhatsApp Shortcuts.user.js
@@ -76,8 +76,15 @@
         });
     }
 
-    function bindChangeOfConversation(){
+    function reactEventHandlers(element){
+        const reactHandlerKey=Object.keys(element).filter(function(item){
+            return item.indexOf('__reactEventHandlers')>=0
+         });
+        const reactHandler=element[reactHandlerKey[0]];
+        return reactHandler;
+    }
 
+    function bindChangeOfConversation(){
         const event = new MouseEvent('onMouseDown', {
             'view': window,
             'bubbles': true,
@@ -86,51 +93,38 @@
 
         Mousetrap.bind(['down'], function() {
         try{
-
-
             const currentIndex = WhatsApp.conversation.currentConversationIndex;
             const totalIndex = WhatsApp.conversation.totalConversationElements;
 
             const nextIndex = (totalIndex + currentIndex - 1) %totalIndex;                
-
             const nextElement = WhatsApp.getConversation()[nextIndex];
+
             if(!nextElement) return;                
 
-            const reactHandlerKey=Object.keys(nextElement).filter(function(item){
-                return item.indexOf('__reactEventHandlers')>=0
-             });
-            const reactHandler=nextElement[reactHandlerKey[0]];
-             
+            const reactHandler=reactEventHandlers(nextElement);
             reactHandler.onMouseDown(event);
-            WhatsApp.conversation.currentConversationIndex = nextIndex;
 
+            WhatsApp.conversation.currentConversationIndex = nextIndex;
             }
         catch(err){
-            console.log(err);
-                
+            console.log(err); 
             }
         });
 
         Mousetrap.bind(['up'], function() {
             try{
-
                 const currentIndex = WhatsApp.conversation.currentConversationIndex;
                 const totalIndex = WhatsApp.conversation.totalConversationElements;
 
                 const nextIndex = (totalIndex + currentIndex + 1) %totalIndex;
-
                 const nextElement = WhatsApp.getConversation()[nextIndex];
 
                 if(!nextElement) return;                
 
-                const reactHandlerKey=Object.keys(nextElement).filter(function(item){
-                    return item.indexOf('__reactEventHandlers')>=0
-                 });
-                const reactHandler=nextElement[reactHandlerKey[0]];
-                 
+                const reactHandler=reactEventHandlers(nextElement);
                 reactHandler.onMouseDown(event);
+                
                 WhatsApp.conversation.currentConversationIndex = nextIndex;
-
             }
             catch(err){
                 console.log(err);  

--- a/WhatsApp Shortcuts.user.js
+++ b/WhatsApp Shortcuts.user.js
@@ -123,7 +123,7 @@
 
                 const reactHandler=reactEventHandlers(nextElement);
                 reactHandler.onMouseDown(event);
-                
+
                 WhatsApp.conversation.currentConversationIndex = nextIndex;
             }
             catch(err){
@@ -131,7 +131,6 @@
             }
         });
     }
-
 
     function doubleClick(selector, _element = null) {
         const element = _element || document.querySelector(selector);
@@ -209,7 +208,6 @@
         addEventListenerToConversation();
         bindChangeOfConversation();
             
-
         document.addEventListener("keydown", function(e) {
             if (e.target.classList.contains("selectable-text")) {
                 const input = WhatsApp.getMessageInput();


### PR DESCRIPTION
Whatsapp web use react list virtualization.  Only 18 conversations can show at a time.

And if scrolling is done in fast speed then html elements are not remain in same order as in chat conversation.
Scrolling should done in normal speed then behaviour of up and down shortcut will be same as expected.
- For up conversation press `up`
- For down conversation press `down`